### PR TITLE
Added a manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include flickrbackup.py


### PR DESCRIPTION
Without this, a normal `pip install flickrbackup` fails because it
can't read `README.rst`:

```
➜  ~  pip install flickrbackup
Downloading/unpacking flickrbackup
...
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
...
```

etc. Probably merits a version bump & re-publishing to PyPI.
